### PR TITLE
Fix httpx rate option

### DIFF
--- a/snortsub.sh
+++ b/snortsub.sh
@@ -464,7 +464,7 @@ FILTERED_OUTPUT_FILE="$OUTPUT_DIR/filtered_results.txt"
 # Build httpx command
 HTTPX_CMD="httpx -sc"
 if [ -n "$RATE_LIMIT" ]; then
-  HTTPX_CMD="$HTTPX_CMD -rate-limit $RATE_LIMIT"
+  HTTPX_CMD="$HTTPX_CMD -rate $RATE_LIMIT"
   verbose_echo "Using rate limit: $RATE_LIMIT requests/second"
 fi
 


### PR DESCRIPTION
## Summary
- fix incorrect flag used for httpx rate limiting

## Testing
- `bash -n snortsub.sh`
- `bash snortsub.sh --help | head -n 3`


------
https://chatgpt.com/codex/tasks/task_b_68821a0b5908832783c604d7f45cea63