### PR TITLE
Add installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This script automates the process of finding subdomains using `subfinder` and `a
 
 ## Prerequisites
 
-Make sure you have the following tools installed:
+This tool relies on a few external utilities:
 
 - [subfinder](https://github.com/projectdiscovery/subfinder)
 - [assetfinder](https://github.com/tomnomnom/assetfinder)
@@ -31,28 +31,18 @@ Make sure you have the following tools installed:
 - [amass](https://github.com/owasp-amass/amass) (optional, for additional enumeration)
 - [dnsx](https://github.com/projectdiscovery/dnsx) (optional, for DNS verification)
 
+You can install all of them automatically using the included `install.sh` script.
+
 ### Installing Dependencies
 
-If you don't have these tools installed, you can install them using the following commands:
+Run the install script to download the required tools:
 
 ```bash
-# Install subfinder
-go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
-
-# Install assetfinder
-go install -v github.com/tomnomnom/assetfinder@latest
-
-# Install httpx
-go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest
-
-# Optional: Install amass
-go install -v github.com/owasp-amass/amass/v3/...@latest
-
-# Optional: Install dnsx
-go install -v github.com/projectdiscovery/dnsx/cmd/dnsx@latest
+chmod +x install.sh
+./install.sh
 ```
 
-Note: These commands require Go to be installed on your system.
+The script uses `go install` under the hood, so make sure Go is installed on your system.
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# install.sh - Install dependencies for Subdomain Enumerator
+set -e
+
+command -v go >/dev/null 2>&1 || { echo "Go is required but not installed. Please install Go and rerun."; exit 1; }
+
+install_tool() {
+  local binary="$1"
+  local package="$2"
+  if command -v "$binary" >/dev/null 2>&1; then
+    echo "$binary already installed"
+  else
+    echo "Installing $binary..."
+    GO111MODULE=on go install -v "$package"
+  fi
+}
+
+install_tool subfinder github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
+install_tool assetfinder github.com/tomnomnom/assetfinder@latest
+install_tool httpx github.com/projectdiscovery/httpx/cmd/httpx@latest
+install_tool amass github.com/owasp-amass/amass/v3/...@latest
+install_tool dnsx github.com/projectdiscovery/dnsx/cmd/dnsx@latest
+
+echo "Installation complete. Make sure \$GOPATH/bin is in your PATH."

--- a/snortsub.sh
+++ b/snortsub.sh
@@ -123,19 +123,14 @@ check_dependencies() {
   if [ ${#missing_deps[@]} -ne 0 ]; then
     error_echo "Missing dependencies: ${missing_deps[*]}"
     echo ""
-    echo "Installation instructions:"
-    echo "  - subfinder: go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest"
-    echo "  - assetfinder: go install -v github.com/tomnomnom/assetfinder@latest"
-    echo "  - httpx: go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest"
-    echo "  - amass: go install -v github.com/owasp-amass/amass/v3/...@latest"
-    echo "  - dnsx: go install -v github.com/projectdiscovery/dnsx/cmd/dnsx@latest"
-    
+    echo "Run ./install.sh to automatically download the required tools."
+
     if [[ " ${missing_deps[*]} " =~ " awk " || " ${missing_deps[*]} " =~ " grep " || " ${missing_deps[*]} " =~ " sort " ]]; then
-      echo "  - Core utilities (awk, grep, sort): These should be available on most systems."
-      echo "    On macOS: brew install coreutils"
-      echo "    On Ubuntu/Debian: apt-get install coreutils"
+      echo "Core utilities (awk, grep, sort) should be available on most systems."
+      echo "On macOS: brew install coreutils"
+      echo "On Ubuntu/Debian: apt-get install coreutils"
     fi
-    
+
     exit $ERROR_DEPENDENCY
   fi
   


### PR DESCRIPTION
## Summary
- add `install.sh` to automatically fetch dependencies
- point README installation instructions to the new script
- update dependency message in `snortsub.sh`

## Testing
- `bash -n snortsub.sh`
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_b_68821ed0db4c83279e576ca1fd1e38c6